### PR TITLE
Fix unhandled boundary values in Perez clearness index binning

### DIFF
--- a/Utilities/SEBESOLWEIGCommonFiles/Perez_v3.py
+++ b/Utilities/SEBESOLWEIGCommonFiles/Perez_v3.py
@@ -144,19 +144,19 @@ def Perez_v3(zen, azimuth, radD, radI, jday, patchchoice, patch_option):
     # sky clearness bins
     if PerezClearness < 1.065:
         intClearness = 0
-    if PerezClearness > 1.065 and PerezClearness < 1.230:
+    elif PerezClearness < 1.230:
         intClearness = 1
-    if PerezClearness > 1.230 and PerezClearness < 1.500:
+    elif PerezClearness < 1.500:
         intClearness = 2
-    if PerezClearness > 1.500 and PerezClearness < 1.950:
+    elif PerezClearness < 1.950:
         intClearness = 3
-    if PerezClearness > 1.950 and PerezClearness < 2.800:
+    elif PerezClearness < 2.800:
         intClearness = 4
-    if PerezClearness > 2.800 and PerezClearness < 4.500:
+    elif PerezClearness < 4.500:
         intClearness = 5
-    if PerezClearness > 4.500 and PerezClearness < 6.200:
+    elif PerezClearness < 6.200:
         intClearness = 6
-    if PerezClearness > 6.200:
+    else:
         intClearness = 7
 
     m_a = acoeff[intClearness,  0] + acoeff[intClearness,  1] * zen + PerezBrightness * (acoeff[intClearness,  2] + acoeff[intClearness,  3] * zen)


### PR DESCRIPTION
## Summary

  The sky clearness index binning in `Perez_v3.py` uses strict inequalities (`<` and `>`), leaving exact boundary values (1.065, 1.230, 1.500, 1.950, 2.800, 4.500, 6.200) unhandled. For these values, `intClearness` is never assigned.

  For example, if `PerezClearness == 1.065`:
  - `< 1.065` → False
  - `> 1.065 and < 1.230` → False
  - `intClearness` is never assigned

  Replaced with an `elif` chain using single comparisons to form a gapless partition matching the standard Perez epsilon bins.