### PR TITLE
Detect QGIS version for umep-reqs extras

### DIFF
--- a/Utilities/umep_installer.py
+++ b/Utilities/umep_installer.py
@@ -85,8 +85,11 @@ def install_umep_python(ver=None):
             if version.parse(str_ver_qgis) <= version.parse("3.9.1")
             else ""
         )
+        # select correct supy version via extras (QGIS 3 vs 4)
+        qgis_major = int(Qgis.QGIS_VERSION.split('.')[0])
+        qgis_extra = f"[qgis{qgis_major}]"
         # --prefer-binary because https://github.com/jameskermode/f90wrap/issues/203
-        list_cmd = f"{str(path_pybin)} -m pip install umep-reqs{str_ver} -U --user --prefer-binary {str_use_feature}".split()
+        list_cmd = f"{str(path_pybin)} -m pip install umep-reqs{qgis_extra}{str_ver} -U --user --prefer-binary {str_use_feature}".split()
         str_info = subprocess.check_output(
             list_cmd, stderr=subprocess.STDOUT, encoding="UTF8"
         )


### PR DESCRIPTION
## Summary

Use `Qgis.QGIS_VERSION` to detect the QGIS major version and pass the correct extra when installing `umep-reqs`:

- QGIS 3 → `pip install umep-reqs[qgis3]`
- QGIS 4 → `pip install umep-reqs[qgis4]`

Companion to UMEP-dev/umep-reqs#14, which moves the supy version pin into optional-dependencies (extras).

## Changes

`Utilities/umep_installer.py`: two lines added in `install_umep_python()` to read `Qgis.QGIS_VERSION` and build the extra string, then interpolated into the existing pip install command.

Ref: UMEP-dev/SUEWS#1252