### PR TITLE
Handle missing future dependency gracefully

### DIFF
--- a/ImageMorphParam/image_morph_param.py
+++ b/ImageMorphParam/image_morph_param.py
@@ -40,9 +40,11 @@ from qgis.PyQt.QtCore import (
     QCoreApplication,
 )
 from builtins import range
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 # from builtins import str
 # from builtins import object
 

--- a/LCZ_Converter/LCZ_converter.py
+++ b/LCZ_Converter/LCZ_converter.py
@@ -49,9 +49,11 @@ from builtins import object
 from builtins import range
 from builtins import str
 from builtins import zip
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 # Initialize Qt resources from file resources.py
 # from . import resources
 # import qgis.analysis

--- a/LandCoverFractionGrid/landcoverfraction_grid.py
+++ b/LandCoverFractionGrid/landcoverfraction_grid.py
@@ -42,9 +42,11 @@ from qgis.PyQt.QtCore import (
 from builtins import object
 from builtins import range
 from builtins import str
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 
 # Initialize Qt resources from file resources.py
 # from . import resources_rc

--- a/SEBE/sebe.py
+++ b/SEBE/sebe.py
@@ -47,9 +47,11 @@ from qgis.PyQt.QtCore import (
 )
 from builtins import object
 from builtins import str
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 
 
 class SEBE(object):

--- a/SOLWEIG/solweig.py
+++ b/SOLWEIG/solweig.py
@@ -50,9 +50,11 @@ from qgis.PyQt.QtCore import (
 from builtins import object
 from builtins import range
 from builtins import str
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 
 
 class SOLWEIG(object):

--- a/SUEWS/suews.py
+++ b/SUEWS/suews.py
@@ -36,9 +36,11 @@ from qgis.PyQt.QtWidgets import QAction, QFileDialog, QMessageBox
 from qgis.PyQt.QtCore import QSettings, QTranslator, qVersion, QCoreApplication
 from builtins import object
 from builtins import str
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 
 
 class SUEWS(object):

--- a/SkyViewFactorCalculator/svf_calculator.py
+++ b/SkyViewFactorCalculator/svf_calculator.py
@@ -46,9 +46,11 @@ from qgis.PyQt.QtCore import (
 )
 from builtins import object
 from builtins import str
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 # Initialize Qt resources from file resources.py
 # from . import resources_rc
 

--- a/SuewsSimple/suews_simple.py
+++ b/SuewsSimple/suews_simple.py
@@ -42,9 +42,11 @@ from qgis.PyQt.QtCore import QSettings, QTranslator, qVersion, QCoreApplication
 from builtins import object
 from builtins import range
 from builtins import str
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 # from .suewssimpleworker import Worker
 # from ..suewsmodel import suewstask
 

--- a/UMEPDownloader/DownloadDataWorker.py
+++ b/UMEPDownloader/DownloadDataWorker.py
@@ -3,9 +3,11 @@ import traceback
 from qgis.core import QgsRasterLayer, QgsRasterPipe, QgsRasterFileWriter
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 from builtins import str
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 
 
 class DownloadDataWorker(QObject):

--- a/UMEPDownloader/GetMetaWorker.py
+++ b/UMEPDownloader/GetMetaWorker.py
@@ -4,9 +4,11 @@ import requests
 import urllib.parse
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 from builtins import str
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 
 
 class GetMetaWorker(QObject):

--- a/UMEPDownloader/umep_downloader.py
+++ b/UMEPDownloader/umep_downloader.py
@@ -71,8 +71,9 @@ import requests
 try:
     from future import standard_library
     standard_library.install_aliases()
-except ImportError:
-    pass
+except ImportError as exc:
+    if getattr(exc, "name", None) != "future":
+        raise
 # Initialize Qt resources from file resources.py
 # from . import resources
 # Import the code for the dialog

--- a/UMEPDownloader/umep_downloader.py
+++ b/UMEPDownloader/umep_downloader.py
@@ -66,10 +66,13 @@ from builtins import object
 from builtins import range
 from builtins import str
 from builtins import map
-from future import standard_library
 import requests
 
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 # Initialize Qt resources from file resources.py
 # from . import resources
 # Import the code for the dialog

--- a/WallHeight/wall_height.py
+++ b/WallHeight/wall_height.py
@@ -43,9 +43,11 @@ from qgis.PyQt.QtCore import (
 )
 from builtins import object
 from builtins import str
-from future import standard_library
-
-standard_library.install_aliases()
+try:
+    from future import standard_library
+    standard_library.install_aliases()
+except ImportError:
+    pass
 
 
 class WallHeight(object):


### PR DESCRIPTION
Title: Handle missing future dependency gracefully

## Summary

- Make `future.standard_library.install_aliases()` optional in UMEP modules that still import it for Python 2 compatibility.
- Allow UMEP to load under QGIS/Python 3.12 when the `future` package is not installed.

## Verification

- Ran `python3 -m py_compile` on representative changed modules, including `LCZ_Converter/LCZ_converter.py` and `UMEPDownloader/umep_downloader.py`.
- Verified locally that the original QGIS failure path can import after installing/handling dependencies.

## Context

QGIS 3.44 with Python 3.12 may not include the third-party `future` package. UMEP currently imports `from future import standard_library` during plugin startup, which can make `classFactory()` fail before the plugin UI opens.
